### PR TITLE
Get llvm8 changes for codechecker

### DIFF
--- a/ClangTidy.h
+++ b/ClangTidy.h
@@ -230,12 +230,13 @@ getCheckOptions(const ClangTidyOptions &Options,
 /// \param StoreCheckProfile If provided, and EnableCheckProfile is true,
 /// the profile will not be output to stderr, but will instead be stored
 /// as a JSON file in the specified directory.
-void runClangTidy(clang::tidy::ClangTidyContext &Context,
-                  const tooling::CompilationDatabase &Compilations,
-                  ArrayRef<std::string> InputFiles,
-                  llvm::IntrusiveRefCntPtr<vfs::FileSystem> BaseFS,
-                  bool EnableCheckProfile = false,
-                  llvm::StringRef StoreCheckProfile = StringRef());
+std::vector<ClangTidyError>
+runClangTidy(clang::tidy::ClangTidyContext &Context,
+             const tooling::CompilationDatabase &Compilations,
+             ArrayRef<std::string> InputFiles,
+             llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
+             bool EnableCheckProfile = false,
+             llvm::StringRef StoreCheckProfile = StringRef());
 
 // FIXME: This interface will need to be significantly extended to be useful.
 // FIXME: Implement confidence levels for displaying/fixing errors.
@@ -243,9 +244,10 @@ void runClangTidy(clang::tidy::ClangTidyContext &Context,
 /// \brief Displays the found \p Errors to the users. If \p Fix is true, \p
 /// Errors containing fixes are automatically applied and reformatted. If no
 /// clang-format configuration file is found, the given \P FormatStyle is used.
-void handleErrors(ClangTidyContext &Context, bool Fix,
+void handleErrors(llvm::ArrayRef<ClangTidyError> Errors,
+                  ClangTidyContext &Context, bool Fix,
                   unsigned &WarningsAsErrorsCount,
-                  llvm::IntrusiveRefCntPtr<vfs::FileSystem> BaseFS);
+                  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS);
 
 /// \brief Serializes replacements into YAML and writes them to the specified
 /// output stream.

--- a/ClangTidyOptions.h
+++ b/ClangTidyOptions.h
@@ -15,7 +15,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Support/ErrorOr.h"
-#include "clang/Basic/VirtualFileSystem.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include <functional>
 #include <map>
 #include <string>
@@ -221,7 +221,7 @@ public:
   FileOptionsProvider(const ClangTidyGlobalOptions &GlobalOptions,
                       const ClangTidyOptions &DefaultOptions,
                       const ClangTidyOptions &OverrideOptions,
-                      llvm::IntrusiveRefCntPtr<vfs::FileSystem> FS = nullptr);
+                      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS = nullptr);
 
   /// \brief Initializes the \c FileOptionsProvider instance with a custom set
   /// of configuration file handlers.
@@ -255,7 +255,7 @@ protected:
   llvm::StringMap<OptionsSource> CachedOptions;
   ClangTidyOptions OverrideOptions;
   ConfigFileHandlers ConfigHandlers;
-  llvm::IntrusiveRefCntPtr<vfs::FileSystem> FS;
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS;
 };
 
 /// \brief Parses LineFilter from JSON and stores it to the \p Options.

--- a/tool/ClangTidyMain.cpp
+++ b/tool/ClangTidyMain.cpp
@@ -254,7 +254,7 @@ static void printStats(const ClangTidyStats &Stats) {
 }
 
 static std::unique_ptr<ClangTidyOptionsProvider> createOptionsProvider(
-   llvm::IntrusiveRefCntPtr<vfs::FileSystem> FS) {
+   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS) {
   ClangTidyGlobalOptions GlobalOptions;
   if (std::error_code Err = parseLineFilter(LineFilter, GlobalOptions)) {
     llvm::errs() << "Invalid LineFilter: " << Err.message() << "\n\nUsage:\n";
@@ -302,7 +302,7 @@ static std::unique_ptr<ClangTidyOptionsProvider> createOptionsProvider(
                                                 OverrideOptions, std::move(FS));
 }
 
-llvm::IntrusiveRefCntPtr<vfs::FileSystem>
+llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 getVfsOverlayFromFile(const std::string &OverlayFile) {
   llvm::IntrusiveRefCntPtr<vfs::OverlayFileSystem> OverlayFS(
       new vfs::OverlayFileSystem(vfs::getRealFileSystem()));
@@ -315,7 +315,7 @@ getVfsOverlayFromFile(const std::string &OverlayFile) {
     return nullptr;
   }
 
-  IntrusiveRefCntPtr<vfs::FileSystem> FS = vfs::getVFSFromYAML(
+  IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS = vfs::getVFSFromYAML(
       std::move(Buffer.get()), /*DiagHandler*/ nullptr, OverlayFile);
   if (!FS) {
     llvm::errs() << "Error: invalid virtual filesystem overlay file '"
@@ -329,7 +329,7 @@ getVfsOverlayFromFile(const std::string &OverlayFile) {
 static int clangTidyMain(int argc, const char **argv) {
   CommonOptionsParser OptionsParser(argc, argv, ClangTidyCategory,
                                     cl::ZeroOrMore);
-  llvm::IntrusiveRefCntPtr<vfs::FileSystem> BaseFS(
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS(
       VfsOverlay.empty() ? vfs::getRealFileSystem()
                          : getVfsOverlayFromFile(VfsOverlay));
   if (!BaseFS)
@@ -421,9 +421,9 @@ static int clangTidyMain(int argc, const char **argv) {
 
   ClangTidyContext Context(std::move(OwningOptionsProvider),
                            AllowEnablingAnalyzerAlphaCheckers);
-  runClangTidy(Context, OptionsParser.getCompilations(), PathList, BaseFS,
-               EnableCheckProfile, ProfilePrefix);
-  ArrayRef<ClangTidyError> Errors = Context.getErrors();
+  std::vector<ClangTidyError> Errors = 
+    runClangTidy(Context, OptionsParser.getCompilations(), PathList, BaseFS, 
+		 EnableCheckProfile, ProfilePrefix);
   bool FoundErrors = llvm::find_if(Errors, [](const ClangTidyError &E) {
                        return E.DiagLevel == ClangTidyError::Error;
                      }) != Errors.end();
@@ -433,7 +433,7 @@ static int clangTidyMain(int argc, const char **argv) {
   unsigned WErrorCount = 0;
 
   // -fix-errors implies -fix.
-  handleErrors(Context, (FixErrors || Fix) && !DisableFixes, WErrorCount,
+  handleErrors(Errors, Context, (FixErrors || Fix) && !DisableFixes, WErrorCount,
                BaseFS);
 
   if (!ExportFixes.empty() && !Errors.empty()) {


### PR DESCRIPTION
We need this changes for LLVM 8 which I borrowed from here:
https://github.com/AliceO2Group/O2CodeChecker/pull/33
Our working patch is here:
https://github.com/cms-sw/cmsdist/pull/5114/commits/382a5ef442908a6290a0ad5bb432dcb11ddbb0cd